### PR TITLE
Hide overlay windows when showing phone account enable/disable screen.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <protected-broadcast android:name="android.intent.action.SHOW_MISSED_CALLS_NOTIFICATION"/>
     <protected-broadcast android:name="com.android.server.telecom.MESSAGE_SENT"/>
 
+    <uses-permission android:name="android.permission.HIDE_NON_SYSTEM_OVERLAY_WINDOWS"/>
 
     <!-- Prevents the activity manager from delaying any activity-start
          requests by this package, including requests immediately after

--- a/src/com/android/server/telecom/settings/EnableAccountPreferenceActivity.java
+++ b/src/com/android/server/telecom/settings/EnableAccountPreferenceActivity.java
@@ -25,11 +25,15 @@ import android.telecom.Log;
 import android.telecom.PhoneAccountHandle;
 import android.telecom.TelecomManager;
 import android.view.MenuItem;
+import android.view.WindowManager;
 
 public class EnableAccountPreferenceActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().addSystemFlags(
+                android.view.WindowManager.LayoutParams
+                        .SYSTEM_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS);
 
         getFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new EnableAccountPreferenceFragment())


### PR DESCRIPTION
Hide any system alert window overlays when the screen that lets the user enable/disable phone accounts is shown.

Test: Manual test with overlay shown from test app; verify that the overlay is hidden when the phone account selection screen is opened. Bug: 246933359

Change-Id: Ia0209d57ee9a672cde4196076845d77941dc3f68 (cherry picked from commit a7d57ace5819c4eef340aaf6744ad441d0369035)
Merged-In: Ia0209d57ee9a672cde4196076845d77941dc3f68